### PR TITLE
Fix rspec rails version for rails 4

### DIFF
--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,3 +1,14 @@
+def rails4?
+  rails_dependency = dependencies.find { |d| d.name == 'rails' }
+  return false unless rails_dependency
+
+  rails_dependency.requirement.to_s.include? '= 4'
+end
+
+def rspec_rails_version
+  return '~> 4.0.1' if rails4?
+end
+
 group :development, :test do
   unless ENV['CI']
     gem 'pry', '<= 0.12.2' if RUBY_VERSION < '2.4'
@@ -5,7 +16,7 @@ group :development, :test do
     gem 'pry-byebug', (RUBY_VERSION >= '2.4' ? '>= 0' : '~> 3.6')
   end
 
-  gem 'rspec-rails'
+  gem 'rspec-rails', rspec_rails_version
 
   gem 'rubocop', require: false unless dependencies.detect { |d| d.name == 'rubocop' }
   gem 'rubocop-lychee', git: 'https://github.com/agileware-jp/rubocop-lychee.git', require: false


### PR DESCRIPTION
昨日からCIでいきなり3.4の全てのテストが
```
undefined local variable or method `use_transactional_tests'
```
で落ちます。

調べてみると、

https://github.com/rspec/rspec-rails/issues/2477

rspec-rails 4.1は rails 4 で動かないから対応しました。