### PR TITLE
Add depency group for rubocop

### DIFF
--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,3 +1,5 @@
+source 'https://rubygems.org'
+
 def rails4?
   rails_dependency = dependencies.find { |d| d.name == 'rails' }
   return false unless rails_dependency

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -23,7 +23,7 @@ group :development, :test do
 end
 
 group :rubocop, :development, :test do
-  dependencies.reject! { |i| %w[rubocop].include? i.name }
+  dependencies.reject! { |i| %w[rubocop rubocop-rails].include? i.name }
   gem 'rubocop', '0.81', require: false # ruby 2.3を対応している最新バージョン
   gem 'rubocop-lychee', git: 'https://github.com/agileware-jp/rubocop-lychee.git', require: false
   gem 'rubocop-no_keyword_args', git: 'https://github.com/agileware-jp/rubocop-no_keyword_args.git', require: false

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -26,12 +26,11 @@ end
 
 # CircleCIのrubocopジョブで、rubocopだけをインストールするためのグループ
 group :rubocop, :development, :test do
-  dependencies.reject! { |i| %w[rubocop rubocop-rails rubocop-performance].include? i.name }
-  # ruby 2.3を対応している最新バージョン
-  gem 'rubocop', '0.81', require: false
-  gem 'rubocop-lychee', git: 'https://github.com/agileware-jp/rubocop-lychee.git', require: false
-  gem 'rubocop-rails', '< 2.6.0', require: false         # 2.6.0からrubocop >= 0.82が求められる
-  gem 'rubocop-performance', '< 1.7.0', require: false   # 1.7.0からrubocop >= 0.82が求められる
+  # 最新のバージョンを使うため、既存のバージョン指定を削除する
+  dependencies.reject! { |i| %w[rubocop rubocop-rails rubocop-performance rubocop-rspec].include? i.name }
+
+  # rubocop, rubocop-rails, rubocop-rspec, rubocop-performanceはrubocop-lycheeの依存に入っているので、記入しない
+  gem 'rubocop-lychee', git: 'https://github.com/agileware-jp/rubocop-lychee.git', ref: 'default-config', require: false
 end
 
 group :test do

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -24,7 +24,7 @@ group :development, :test do
   gem 'lychee-dev', git: 'https://github.com/agileware-jp/lychee-dev.git', ref: 'v0.2.0', require: false
 end
 
-# CircleCIのrubocopジョブで、rubocopだけをインストールするためのグループ
+# CircleCIのrubocopジョブで、rubocopだけをインストールするためのグループ
 group :rubocop, :development, :test do
   dependencies.reject! { |i| %w[rubocop rubocop-rails rubocop-performance].include? i.name }
   # ruby 2.3を対応している最新バージョン

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -25,7 +25,7 @@ group :development, :test do
 end
 
 group :rubocop, :development, :test do
-  dependencies.reject! { |i| %w[rubocop rubocop-rails].include? i.name }
+  dependencies.reject! { |i| %w[rubocop rubocop-rails rubocop-performance].include? i.name }
   gem 'rubocop', '0.81', require: false # ruby 2.3を対応している最新バージョン
   gem 'rubocop-lychee', git: 'https://github.com/agileware-jp/rubocop-lychee.git', require: false
   gem 'rubocop-no_keyword_args', git: 'https://github.com/agileware-jp/rubocop-no_keyword_args.git', require: false

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -18,11 +18,17 @@ group :development, :test do
 
   gem 'rspec-rails', rspec_rails_version
 
-  gem 'rubocop', require: false unless dependencies.detect { |d| d.name == 'rubocop' }
-  gem 'rubocop-lychee', git: 'https://github.com/agileware-jp/rubocop-lychee.git', require: false
-
   dependencies.reject! { |i| %w[capybara nokogiri selenium-webdriver].include? i.name } # Ensure Capybara + Selenium have new version
   gem 'lychee-dev', git: 'https://github.com/agileware-jp/lychee-dev.git', ref: 'v0.2.0', require: false
+end
+
+group :rubocop, :development, :test do
+  dependencies.reject! { |i| %w[rubocop].include? i.name }
+  gem 'rubocop', '0.81', require: false # ruby 2.3を対応している最新バージョン
+  gem 'rubocop-lychee', git: 'https://github.com/agileware-jp/rubocop-lychee.git', require: false
+  gem 'rubocop-no_keyword_args', git: 'https://github.com/agileware-jp/rubocop-no_keyword_args.git', require: false
+  gem 'rubocop-rails', '< 2.6.0', require: false # 2.6.0からrubocop >= 0.82が求められる
+  gem 'rubocop-performance', '< 1.7.0', require: false # 1.7.0からrubocop >= 0.82が求められる
 end
 
 group :test do

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'https://rubygems.org' # CircleCIのrubocopジョブでGemfileとして使われるので、sourceが必須
 
 def rails4?
   rails_dependency = dependencies.find { |d| d.name == 'rails' }
@@ -24,13 +24,15 @@ group :development, :test do
   gem 'lychee-dev', git: 'https://github.com/agileware-jp/lychee-dev.git', ref: 'v0.2.0', require: false
 end
 
+# CircleCIのrubocopジョブで、rubocopだけをインストールするためのグループ
 group :rubocop, :development, :test do
   dependencies.reject! { |i| %w[rubocop rubocop-rails rubocop-performance].include? i.name }
-  gem 'rubocop', '0.81', require: false # ruby 2.3を対応している最新バージョン
+  # ruby 2.3を対応している最新バージョン
+  gem 'rubocop', '0.81', require: false
   gem 'rubocop-lychee', git: 'https://github.com/agileware-jp/rubocop-lychee.git', require: false
   gem 'rubocop-no_keyword_args', git: 'https://github.com/agileware-jp/rubocop-no_keyword_args.git', require: false
-  gem 'rubocop-rails', '< 2.6.0', require: false # 2.6.0からrubocop >= 0.82が求められる
-  gem 'rubocop-performance', '< 1.7.0', require: false # 1.7.0からrubocop >= 0.82が求められる
+  gem 'rubocop-rails', '< 2.6.0', require: false         # 2.6.0からrubocop >= 0.82が求められる
+  gem 'rubocop-performance', '< 1.7.0', require: false   # 1.7.0からrubocop >= 0.82が求められる
 end
 
 group :test do

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -30,7 +30,6 @@ group :rubocop, :development, :test do
   # ruby 2.3を対応している最新バージョン
   gem 'rubocop', '0.81', require: false
   gem 'rubocop-lychee', git: 'https://github.com/agileware-jp/rubocop-lychee.git', require: false
-  gem 'rubocop-no_keyword_args', git: 'https://github.com/agileware-jp/rubocop-no_keyword_args.git', require: false
   gem 'rubocop-rails', '< 2.6.0', require: false         # 2.6.0からrubocop >= 0.82が求められる
   gem 'rubocop-performance', '< 1.7.0', require: false   # 1.7.0からrubocop >= 0.82が求められる
 end


### PR DESCRIPTION
- rubocop 関連のgemだけをインストールする `rubocop` グループを追加した
  - development, test にもインストールするようにしておいた（手元開発環境も同じバージョンになるため）
- バージョンは全部Ruby 2.3を対応できる最新に制限した