### PR TITLE
Remove the restriction on Puma

### DIFF
--- a/Gemfile.local
+++ b/Gemfile.local
@@ -36,10 +36,4 @@ end
 group :test do
   gem 'webdrivers' if dependencies.none? { |i| i.name == 'webdrivers' }
   gem 'rspec_junit_formatter'
-
-  # https://github.com/teamcapybara/capybara/pull/2530 を含んだcapybara.gemが
-  # リリースされれば以下は不要になる．
-  if dependencies.reject! { |i| i.name == 'puma' && i.requirements_list == [">= 0"] }
-    gem 'puma', '~> 5.6.4'
-  end
 end


### PR DESCRIPTION
Remove the restriction on Puma because Capybara 3.38.0 has been released with support for Puma 6.0:tada:

https://github.com/teamcapybara/capybara/pull/2530#issuecomment-1302990510