### PR TITLE
NodeJSインストール用スクリプトの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/exe/node_install

--- a/exe/node_install_for_check
+++ b/exe/node_install_for_check
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+usage="usage: $(basename $0) node_version"
+
+set -eu
+
+version="${1:-unspec}"
+if test "$version" = unspec
+then
+  echo "$usage" 1>&2
+  exit 1
+fi
+
+if test "x$(node --version | sed -e 's/^v//')" != "x$version"
+then
+  echo "$version is not installed" 1>&2
+  exit 1
+fi

--- a/exe/node_install_for_mise
+++ b/exe/node_install_for_mise
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+usage="usage: $(basename $0) node_version"
+
+set -eu
+
+version="${1:-unspec}"
+if test "$version" = unspec
+then
+  echo "$usage" 1>&2
+  exit 1
+fi
+
+set -x
+exec mise install "node@$version"

--- a/exe/node_install_for_nodenv
+++ b/exe/node_install_for_nodenv
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+usage="usage: $(basename $0) node_version"
+
+set -eu
+
+version="${1:-unspec}"
+if test "$version" = unspec
+then
+  echo "$usage" 1>&2
+  exit 1
+fi
+
+set -x
+exec nodenv install --skip-existing "$version"


### PR DESCRIPTION
exe/以下に配置するのはBundlerのデフォルトに合わせた．

exe/node_install_for_check は主にCI用で，NodeJSがインストール済のDockerイメージでCIのステップが動作する状況において，NodeJSをインストールする代わりに使う．
